### PR TITLE
feat(payment): INT-838 [NGCheckout] Add Google Pay button to Cart Page

### DIFF
--- a/src/checkout-buttons/checkout-button-options.ts
+++ b/src/checkout-buttons/checkout-button-options.ts
@@ -1,6 +1,6 @@
 import { RequestOptions } from '../common/http-request';
 
-import { BraintreePaypalButtonInitializeOptions } from './strategies';
+import { BraintreePaypalButtonInitializeOptions, GooglePayBraintreeButtonInitializeOptions } from './strategies';
 
 /**
  * The set of options for configuring the checkout button.
@@ -24,4 +24,10 @@ export interface CheckoutButtonInitializeOptions extends CheckoutButtonOptions {
      * omitted unless you need to support Braintree Credit.
      */
     braintreepaypalcredit?: BraintreePaypalButtonInitializeOptions;
+
+    /**
+     * The options that are required to facilitate Braintree GooglePay. They can be
+     * omitted unles you need to support Braintree GooglePay.
+     */
+    googlepaybraintree?: GooglePayBraintreeButtonInitializeOptions;
 }

--- a/src/checkout-buttons/create-checkout-button-registry.ts
+++ b/src/checkout-buttons/create-checkout-button-registry.ts
@@ -2,13 +2,16 @@ import { createFormPoster } from '@bigcommerce/form-poster';
 import { RequestSender } from '@bigcommerce/request-sender';
 import { getScriptLoader } from '@bigcommerce/script-loader';
 
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../billing';
 import { CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../checkout';
 import { Registry } from '../common/registry';
 import { ConfigActionCreator, ConfigRequestSender } from '../config';
+import { PaymentMethodActionCreator, PaymentMethodRequestSender } from '../payment';
 import { BraintreeScriptLoader, BraintreeSDKCreator } from '../payment/strategies/braintree';
+import { GooglePayBraintreeInitializer, GooglePayPaymentProcessor, GooglePayScriptLoader } from '../payment/strategies/googlepay';
 import { PaypalScriptLoader } from '../payment/strategies/paypal';
 
-import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy } from './strategies';
+import { BraintreePaypalButtonStrategy, CheckoutButtonStrategy, GooglePayBraintreeButtonStrategy } from './strategies';
 
 export default function createCheckoutButtonRegistry(
     store: CheckoutStore,
@@ -20,6 +23,10 @@ export default function createCheckoutButtonRegistry(
         new CheckoutRequestSender(requestSender),
         new ConfigActionCreator(new ConfigRequestSender(requestSender))
     );
+    const braintreeScriptLoader = new BraintreeScriptLoader(scriptLoader);
+    const braintreeSDKCreator = new BraintreeSDKCreator(braintreeScriptLoader);
+    const paymentMethodActionCreator = new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender));
+    const formPoster = createFormPoster();
 
     registry.register('braintreepaypal', () =>
         new BraintreePaypalButtonStrategy(
@@ -27,7 +34,7 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             new PaypalScriptLoader(scriptLoader),
-            createFormPoster()
+            formPoster
         )
     );
 
@@ -37,8 +44,25 @@ export default function createCheckoutButtonRegistry(
             checkoutActionCreator,
             new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader)),
             new PaypalScriptLoader(scriptLoader),
-            createFormPoster(),
+            formPoster,
             true
+        )
+    );
+
+    registry.register('googlepaybraintree', () =>
+        new GooglePayBraintreeButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            new GooglePayPaymentProcessor(
+                store,
+                paymentMethodActionCreator,
+                new GooglePayScriptLoader(scriptLoader),
+                new GooglePayBraintreeInitializer(braintreeSDKCreator),
+                new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender)),
+                requestSender
+            )
         )
     );
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-options.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-options.ts
@@ -1,0 +1,44 @@
+import { StandardError } from '../../../common/error/errors';
+import { BraintreeError } from '../../../payment/strategies/braintree';
+import { ButtonColor, ButtonType, EnvironmentType } from '../../../payment/strategies/googlepay/googlepay';
+
+export interface GooglePayBraintreeButtonInitializeOptions {
+    /**
+     * The ID of a container which the checkout button should be inserted.
+     */
+    container: string;
+
+    /**
+     * This one is used to set the environment of Braintree. Default is 'PRODUCTION'
+     */
+    environment?: EnvironmentType;
+
+    /**
+     * The color of the GooglePay button that will be inserted.
+     *  black (default): a black button suitable for use on white or light backgrounds.
+     *  white: a white button suitable for use on colorful backgrounds.
+     */
+    buttonColor?: ButtonColor;
+
+    /**
+     * The size of the GooglePay button that will be inserted.
+     *  long: "Buy with Google Pay" button (default). A translated button label may appear
+     *         if a language specified in the viewer's browser matches an available language.
+     *  short: Google Pay payment button without the "Buy with" text.
+     */
+    buttonType?: ButtonType;
+
+    /**
+     * A callback that gets called if unable to authorize and tokenize payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onAuthorizeError?(error: BraintreeError | StandardError): void;
+
+    /**
+     * A callback that gets called if unable to submit payment.
+     *
+     * @param error - The error object describing the failure.
+     */
+    onPaymentError?(error: BraintreeError | StandardError): void;
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -135,6 +135,16 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
                 }
             });
 
+            it('fails to set methodId if is not provided ', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.UndefinedMethodId);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+
             it('fails to initialize the strategy if no valid container id is supplied', async () => {
                 checkoutButtonOptions = getCheckoutButtonOptions(Mode.InvalidContainer);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -213,7 +213,6 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
             spyOn(paymentProcessor, 'displayWallet').and.returnValue(Promise.resolve(paymentData));
             spyOn(paymentProcessor, 'handleSuccess').and.returnValue(Promise.resolve());
             spyOn(paymentProcessor, 'updateShippingAddress').and.returnValue(Promise.resolve());
-            spyOn(paymentProcessor, 'updateBillingAddress').and.returnValue(Promise.resolve());
 
             await strategy.initialize(googlePayOptions).then(() => {
                 walletButton.click();

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -145,6 +145,16 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
                 }
             });
 
+            it('fails to initialize the strategy if no container id is supplied', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.UndefinedMethodId);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+
             it('fails to initialize the strategy if no valid container id is supplied', async () => {
                 checkoutButtonOptions = getCheckoutButtonOptions(Mode.InvalidContainer);
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -1,0 +1,225 @@
+import { createFormPoster, FormPoster } from '@bigcommerce/form-poster';
+import { createRequestSender, RequestSender } from '@bigcommerce/request-sender';
+import { createScriptLoader } from '@bigcommerce/script-loader';
+
+import { GooglePayBraintreeButtonStrategy } from '../';
+import { getCartState } from '../../../cart/carts.mock';
+import { createCheckoutStore, CheckoutActionCreator, CheckoutRequestSender, CheckoutStore } from '../../../checkout';
+import { getCheckoutState } from '../../../checkout/checkouts.mock';
+import { InvalidArgumentError, MissingDataError } from '../../../common/error/errors';
+import { ConfigActionCreator, ConfigRequestSender } from '../../../config';
+import { getConfigState } from '../../../config/configs.mock';
+import { getCustomerState } from '../../../customer/customers.mock';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
+import { getPaymentMethodsState } from '../../../payment/payment-methods.mock';
+import { createGooglePayPaymentProcessor, GooglePaymentData, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+
+import { getCheckoutButtonOptions, getPaymentMethod, Mode } from './googlepay-braintree-button.mock';
+
+describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
+    let container: HTMLDivElement;
+    let formPoster: FormPoster;
+    let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+    let paymentMethod: PaymentMethod;
+    let paymentMethodActionCreator: PaymentMethodActionCreator;
+    let paymentProcessor: GooglePayPaymentProcessor;
+    let checkoutActionCreator: CheckoutActionCreator;
+    let requestSender: RequestSender;
+    let store: CheckoutStore;
+    let strategy: GooglePayBraintreeButtonStrategy;
+    let walletButton: HTMLAnchorElement;
+
+    beforeEach(() => {
+        paymentMethod = getPaymentMethod();
+
+        store = createCheckoutStore({
+            checkout: getCheckoutState(),
+            customer: getCustomerState(),
+            config: getConfigState(),
+            cart: getCartState(),
+            paymentMethods: getPaymentMethodsState(),
+        });
+
+        requestSender = createRequestSender();
+        paymentMethodActionCreator = new PaymentMethodActionCreator(
+            new PaymentMethodRequestSender(requestSender)
+        );
+
+        checkoutActionCreator = checkoutActionCreator = new CheckoutActionCreator(
+            new CheckoutRequestSender(requestSender),
+            new ConfigActionCreator(new ConfigRequestSender(requestSender))
+        );
+
+        paymentProcessor = createGooglePayPaymentProcessor(store, createScriptLoader());
+
+        formPoster = createFormPoster();
+
+        strategy = new GooglePayBraintreeButtonStrategy(
+            store,
+            formPoster,
+            checkoutActionCreator,
+            paymentMethodActionCreator,
+            paymentProcessor
+        );
+
+        jest.spyOn(store, 'dispatch')
+            .mockReturnValue(Promise.resolve(store.getState()));
+
+        jest.spyOn(paymentProcessor, 'initialize')
+            .mockReturnValue(Promise.resolve());
+
+        jest.spyOn(store.getState().paymentMethods, 'getPaymentMethod')
+            .mockReturnValue(paymentMethod);
+
+        jest.spyOn(formPoster, 'postForm')
+            .mockReturnValue(Promise.resolve());
+
+        container = document.createElement('div');
+        container.setAttribute('id', 'googlePayCheckoutButton');
+        walletButton = document.createElement('a');
+        walletButton.setAttribute('id', 'mockButton');
+
+        jest.spyOn(paymentProcessor, 'createButton')
+            .mockReturnValue(walletButton);
+
+        jest.spyOn(walletButton, 'addEventListener');
+
+        jest.spyOn(walletButton, 'removeEventListener');
+
+        container.appendChild(walletButton);
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates an instance of GooglePayBraintreeButtonStrategy', () => {
+        expect(strategy).toBeInstanceOf(GooglePayBraintreeButtonStrategy);
+    });
+
+    describe('#initialize()', () => {
+
+        describe('Payment method exist', () => {
+
+            it('adds the event listener to the wallet button', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions();
+
+                await strategy.initialize(checkoutButtonOptions);
+
+                expect(walletButton.addEventListener).toHaveBeenCalled();
+            });
+
+            it('Validates if strategy is been initialized', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions();
+
+                await strategy.initialize(checkoutButtonOptions);
+
+                setTimeout(() => {
+                    strategy.initialize(checkoutButtonOptions);
+                }, 0);
+
+                strategy.initialize(checkoutButtonOptions);
+
+                expect(paymentProcessor.initialize).toHaveBeenCalledTimes(1);
+            });
+
+            it('fails to initialize the strategy if no CheckoutButtonInitializeOptions is provided ', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.Incomplete);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(MissingDataError);
+                }
+            });
+
+            it('fails to initialize the strategy if no valid container id is supplied', async () => {
+                checkoutButtonOptions = getCheckoutButtonOptions(Mode.InvalidContainer);
+
+                try {
+                    await strategy.initialize(checkoutButtonOptions);
+                } catch (e) {
+                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                }
+            });
+        });
+    });
+
+    describe('#deinitialize()', () => {
+        let checkoutButtonOptions: CheckoutButtonInitializeOptions;
+
+        beforeEach(() => {
+            checkoutButtonOptions = getCheckoutButtonOptions();
+        });
+
+        it('succesfully deinitializes the strategy', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize(checkoutButtonOptions);
+
+            if (checkoutButtonOptions.googlepaybraintree) {
+                const button = document.getElementById(checkoutButtonOptions.googlepaybraintree.container);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+
+        it('Validates if strategy is loaded before call deinitialize', async () => {
+            await strategy.deinitialize(checkoutButtonOptions);
+
+            if (checkoutButtonOptions.googlepaybraintree) {
+                const button = document.getElementById(checkoutButtonOptions.googlepaybraintree.container);
+
+                if (button) {
+                    expect(button.firstChild).toBe(null);
+                }
+            }
+
+            container = document.createElement('div');
+            document.body.appendChild(container);
+        });
+    });
+
+    describe('#handleWalletButtonClick', () => {
+        let googlePayOptions: CheckoutButtonInitializeOptions;
+        let paymentData: GooglePaymentData;
+
+        beforeEach(() => {
+            googlePayOptions = {
+                methodId: 'googlepay',
+                googlepaybraintree: {
+                    container: 'googlePayCheckoutButton',
+                },
+            };
+
+            paymentData = {
+                cardInfo: {
+                    billingAddress: {},
+                },
+                paymentMethodToken: {},
+                shippingAddress: {},
+                email: 'email',
+            } as GooglePaymentData;
+        });
+
+        it('handles wallet button event', async () => {
+            spyOn(paymentProcessor, 'displayWallet').and.returnValue(Promise.resolve(paymentData));
+            spyOn(paymentProcessor, 'handleSuccess').and.returnValue(Promise.resolve());
+            spyOn(paymentProcessor, 'updateShippingAddress').and.returnValue(Promise.resolve());
+            spyOn(paymentProcessor, 'updateBillingAddress').and.returnValue(Promise.resolve());
+
+            await strategy.initialize(googlePayOptions).then(() => {
+                walletButton.click();
+            });
+
+            expect(paymentProcessor.initialize).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
@@ -1,0 +1,143 @@
+import { FormPoster } from '@bigcommerce/form-poster';
+
+import { Checkout, CheckoutActionCreator, CheckoutStore } from '../../../checkout';
+import { InvalidArgumentError, MissingDataError, MissingDataErrorType } from '../../../common/error/errors';
+import { bindDecorator as bind } from '../../../common/utility';
+import { PaymentMethodActionCreator } from '../../../payment';
+import { GooglePayAddress, GooglePayPaymentProcessor } from '../../../payment/strategies/googlepay';
+import { CheckoutButtonInitializeOptions, CheckoutButtonOptions } from '../../checkout-button-options';
+import CheckoutButtonStrategy from '../checkout-button-strategy';
+
+export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStrategy {
+    private _methodId?: string;
+    private _checkout?: Checkout;
+    private _walletButton?: HTMLElement;
+
+    constructor(
+        private _store: CheckoutStore,
+        private _formPoster: FormPoster,
+        private _checkoutActionCreator: CheckoutActionCreator,
+        private _paymentMethodActionCreator: PaymentMethodActionCreator,
+        private _googlePayPaymentProcessor: GooglePayPaymentProcessor
+    ) {
+        super();
+    }
+
+    initialize(options: CheckoutButtonInitializeOptions): Promise<void> {
+        if (this._isInitialized) {
+            return super.initialize(options);
+        }
+
+        const { googlepaybraintree, methodId } = options;
+
+        this.methodId = methodId;
+
+        if (!googlepaybraintree) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._store.dispatch(this._checkoutActionCreator.loadDefaultCheckout())
+            .then(stateCheckout => {
+                this._checkout = stateCheckout.checkout.getCheckout();
+                if (!this._checkout || !this._checkout.cart.id) {
+                    throw new MissingDataError(MissingDataErrorType.MissingCart);
+                }
+
+                return this._googlePayPaymentProcessor.initialize(this.methodId)
+                    .then(() => {
+                        this._walletButton = this._createSignInButton(googlepaybraintree.container);
+
+                        if (this._walletButton) {
+                            this._walletButton.addEventListener('click', this._handleWalletButtonClick);
+                        }
+                    });
+            }).then(() => super.initialize(options));
+    }
+
+    deinitialize(options: CheckoutButtonOptions): Promise<void> {
+        if (!this._isInitialized) {
+            return super.deinitialize(options);
+        }
+
+        if (this._walletButton && this._walletButton.parentNode) {
+            this._walletButton.parentNode.removeChild(this._walletButton);
+            this._walletButton.removeEventListener('click', this._handleWalletButtonClick);
+            this._walletButton = undefined;
+        }
+
+        return this._googlePayPaymentProcessor.deinitialize()
+            .then(() => super.deinitialize(options));
+    }
+
+    private get methodId(): string {
+        if (!this._methodId) {
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
+        }
+
+        return this._methodId;
+    }
+
+    private set methodId(value: string) {
+        if (!value) {
+            throw new InvalidArgumentError();
+        }
+
+        this._methodId = value;
+    }
+
+    private _createSignInButton(containerId: string): HTMLElement {
+        const container = document.querySelector(`#${containerId}`);
+
+        if (!container) {
+            throw new InvalidArgumentError('Unable to create sign-in button without valid container ID.');
+        }
+
+        const googlePayButton = this._googlePayPaymentProcessor.createButton(() => this._onPaymentSelectComplete);
+
+        container.appendChild(googlePayButton);
+
+        return googlePayButton;
+    }
+
+    @bind
+    private _handleWalletButtonClick(event: Event): Promise<void> {
+        event.preventDefault();
+
+        let billingAddress: GooglePayAddress;
+        let shippingAddress: GooglePayAddress;
+
+        return this._googlePayPaymentProcessor.displayWallet()
+            .then(paymentData => {
+                billingAddress = paymentData.cardInfo.billingAddress;
+                shippingAddress = paymentData.shippingAddress;
+                return this._googlePayPaymentProcessor.handleSuccess(paymentData);
+            })
+            .then(() => this._updateAddressAndPayment(billingAddress, shippingAddress))
+            .catch(error => this._onError(error));
+    }
+
+    private _onPaymentSelectComplete(): void {
+        this._formPoster.postForm('/checkout.php', {
+            headers: {
+                Accept: 'text/html',
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+        });
+    }
+
+    private _onError(error?: Error): void {
+        if (error && error.message !== 'CANCELED') {
+            throw new Error(error.message);
+        }
+    }
+
+    private _updateAddressAndPayment(billingAddress: GooglePayAddress, shippingAddress: GooglePayAddress): Promise<void> {
+        return Promise.all([
+            this._googlePayPaymentProcessor.updateBillingAddress(billingAddress),
+            this._googlePayPaymentProcessor.updateShippingAddress(shippingAddress),
+            this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
+            this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this.methodId)),
+        ]).then(() => this._onPaymentSelectComplete());
+    }
+
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
@@ -103,16 +103,14 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
     private _handleWalletButtonClick(event: Event): Promise<void> {
         event.preventDefault();
 
-        let billingAddress: GooglePayAddress;
         let shippingAddress: GooglePayAddress;
 
         return this._googlePayPaymentProcessor.displayWallet()
             .then(paymentData => {
-                billingAddress = paymentData.cardInfo.billingAddress;
                 shippingAddress = paymentData.shippingAddress;
                 return this._googlePayPaymentProcessor.handleSuccess(paymentData);
             })
-            .then(() => this._updateAddressAndPayment(billingAddress, shippingAddress))
+            .then(() => this._updateAddressAndPayment(shippingAddress))
             .catch(error => this._onError(error));
     }
 
@@ -131,9 +129,8 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
         }
     }
 
-    private _updateAddressAndPayment(billingAddress: GooglePayAddress, shippingAddress: GooglePayAddress): Promise<void> {
+    private _updateAddressAndPayment(shippingAddress: GooglePayAddress): Promise<void> {
         return Promise.all([
-            this._googlePayPaymentProcessor.updateBillingAddress(billingAddress),
             this._googlePayPaymentProcessor.updateShippingAddress(shippingAddress),
             this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
             this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this.methodId)),

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
@@ -38,6 +38,7 @@ export function getPaymentMethod(): PaymentMethod {
 export enum Mode {
     Full,
     UndefinedMethodId,
+    UndefinedContainer,
     InvalidContainer,
     Incomplete,
 }
@@ -46,8 +47,10 @@ export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButton
     const methodId = { methodId: 'googlepay' };
     const undefinedMethodId = { methodId: '' };
     const container = { container: 'googlePayCheckoutButton' };
+    const undefinedContainer = { container: '' };
     const invalidContainer = { container: 'invalid_container' };
     const googlepay = { googlepaybraintree: { ...container } };
+    const googlepayWithUndefinedContainer = { googlepaybraintree: { ...undefinedContainer } };
     const googlepayWithInvalidContainer = { googlepaybraintree: { ...invalidContainer } };
 
     switch (mode) {
@@ -56,6 +59,9 @@ export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButton
         }
         case Mode.UndefinedMethodId: {
             return { ...undefinedMethodId };
+        }
+        case Mode.UndefinedContainer: {
+            return { ...methodId, ...googlepayWithUndefinedContainer };
         }
         case Mode.InvalidContainer: {
             return { ...methodId, ...googlepayWithInvalidContainer };

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
@@ -1,0 +1,63 @@
+import { createRequestSender } from '@bigcommerce/request-sender/lib';
+import { getScriptLoader } from '@bigcommerce/script-loader/lib/';
+
+import { BillingAddressActionCreator, BillingAddressRequestSender } from '../../../billing';
+import { CheckoutStore } from '../../../checkout';
+import { PaymentMethod, PaymentMethodActionCreator, PaymentMethodRequestSender } from '../../../payment';
+import { getGooglePay } from '../../../payment/payment-methods.mock';
+import { BraintreeScriptLoader, BraintreeSDKCreator } from '../../../payment/strategies/braintree';
+import { GooglePayBraintreeInitializer, GooglePayPaymentProcessor, GooglePayScriptLoader } from '../../../payment/strategies/googlepay';
+import { CheckoutButtonInitializeOptions } from '../../checkout-button-options';
+
+const requestSender = createRequestSender();
+const scriptLoader = getScriptLoader();
+const braintreeSdkCreator = new BraintreeSDKCreator(new BraintreeScriptLoader(scriptLoader));
+
+export function getGooglePayPaymentProcessor(store: CheckoutStore): GooglePayPaymentProcessor {
+
+    return new GooglePayPaymentProcessor(
+        store,
+        new PaymentMethodActionCreator(new PaymentMethodRequestSender(requestSender)),
+        new GooglePayScriptLoader(scriptLoader),
+        new GooglePayBraintreeInitializer(braintreeSdkCreator),
+        new BillingAddressActionCreator(new BillingAddressRequestSender(requestSender)),
+        requestSender
+    );
+}
+
+export function getPaymentMethod(): PaymentMethod {
+    return {
+        ...getGooglePay(),
+        initializationData: {
+            checkoutId: 'checkoutId',
+            allowedCardTypes: ['visa', 'amex', 'mastercard'],
+        },
+    };
+}
+
+export enum Mode {
+    Full,
+    UndefinedMethodId,
+    InvalidContainer,
+    Incomplete,
+}
+
+export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
+    const methodId = { methodId: 'googlepay' };
+    const container = { container: 'googlePayCheckoutButton' };
+    const invalidContainer = { container: 'invalid_container' };
+    const googlepay = { googlepaybraintree: { ...container } };
+    const googlepayWithInvalidContainer = { googlepaybraintree: { ...invalidContainer } };
+
+    switch (mode) {
+        case Mode.Incomplete: {
+            return { ...methodId };
+        }
+        case Mode.InvalidContainer: {
+            return { ...methodId, ...googlepayWithInvalidContainer };
+        }
+        default: {
+            return { ...methodId, ...googlepay };
+        }
+    }
+}

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button.mock.ts
@@ -44,6 +44,7 @@ export enum Mode {
 
 export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButtonInitializeOptions {
     const methodId = { methodId: 'googlepay' };
+    const undefinedMethodId = { methodId: '' };
     const container = { container: 'googlePayCheckoutButton' };
     const invalidContainer = { container: 'invalid_container' };
     const googlepay = { googlepaybraintree: { ...container } };
@@ -52,6 +53,9 @@ export function getCheckoutButtonOptions(mode: Mode = Mode.Full): CheckoutButton
     switch (mode) {
         case Mode.Incomplete: {
             return { ...methodId };
+        }
+        case Mode.UndefinedMethodId: {
+            return { ...undefinedMethodId };
         }
         case Mode.InvalidContainer: {
             return { ...methodId, ...googlepayWithInvalidContainer };

--- a/src/checkout-buttons/strategies/index.ts
+++ b/src/checkout-buttons/strategies/index.ts
@@ -1,4 +1,6 @@
 export { default as BraintreePaypalButtonStrategy } from './braintree-paypal-button-strategy';
+export { default as GooglePayBraintreeButtonStrategy } from './googlepay/googlepay-braintree-button-strategy';
 export { default as CheckoutButtonStrategy } from './checkout-button-strategy';
 
 export { BraintreePaypalButtonInitializeOptions } from './braintree-paypal-button-options';
+export { GooglePayBraintreeButtonInitializeOptions } from './googlepay/googlepay-braintree-button-options';


### PR DESCRIPTION
## What? [INT-838](https://jira.bigcommerce.com/browse/INT-838)
Display the checkout button on the cart page and quick cart.
This PR depends on [PR#26299](https://github.com/bigcommerce/bigcommerce/pull/26299).

## Why?
We should display the checkout button on the cart page and also the quick cart. 

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/47098010-163d2280-d1f8-11e8-8d61-0d930f8f7de5.png)

![image](https://user-images.githubusercontent.com/1013633/47031374-4d96cb00-d135-11e8-8561-84d6620683b1.png)
![image](https://user-images.githubusercontent.com/1013633/47031416-68693f80-d135-11e8-9a25-565765e55abb.png)

![image](https://user-images.githubusercontent.com/1013633/47031221-0f011080-d135-11e8-98f5-e4a4b77051c2.png)


@vmparra 
