### PR TITLE
feat(payment): INT-858 Remove getter and setter

### DIFF
--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -88,6 +88,8 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
 
         jest.spyOn(walletButton, 'removeEventListener');
 
+        jest.spyOn(paymentProcessor, 'deinitialize');
+
         container.appendChild(walletButton);
         document.body.appendChild(container);
     });
@@ -173,6 +175,14 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
 
         beforeEach(() => {
             checkoutButtonOptions = getCheckoutButtonOptions();
+        });
+
+        it('check if googlepay payment processor deinitialize is called', async () => {
+            await strategy.initialize(checkoutButtonOptions);
+
+            strategy.deinitialize(checkoutButtonOptions);
+
+            expect(paymentProcessor.deinitialize).toBeCalled();
         });
 
         it('succesfully deinitializes the strategy', async () => {

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.spec.ts
@@ -142,7 +142,7 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
                 try {
                     await strategy.initialize(checkoutButtonOptions);
                 } catch (e) {
-                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                    expect(e).toBeInstanceOf(MissingDataError);
                 }
             });
 
@@ -152,7 +152,7 @@ describe('GooglePayBraintreeCheckoutButtonStrategy', () => {
                 try {
                     await strategy.initialize(checkoutButtonOptions);
                 } catch (e) {
-                    expect(e).toBeInstanceOf(InvalidArgumentError);
+                    expect(e).toBeInstanceOf(MissingDataError);
                 }
             });
 

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
@@ -85,7 +85,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
 
     private _getMethodId(): string {
         if (!this._methodId) {
-            throw new InvalidArgumentError();
+            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
         }
 
         return this._methodId;

--- a/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
+++ b/src/checkout-buttons/strategies/googlepay/googlepay-braintree-button-strategy.ts
@@ -30,7 +30,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
 
         const { googlepaybraintree, methodId } = options;
 
-        this.methodId = methodId;
+        this._methodId = methodId;
 
         if (!googlepaybraintree) {
             throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
@@ -43,7 +43,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
                     throw new MissingDataError(MissingDataErrorType.MissingCart);
                 }
 
-                return this._googlePayPaymentProcessor.initialize(this.methodId)
+                return this._googlePayPaymentProcessor.initialize(this._getMethodId())
                     .then(() => {
                         this._walletButton = this._createSignInButton(googlepaybraintree.container);
 
@@ -69,22 +69,6 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
             .then(() => super.deinitialize(options));
     }
 
-    private get methodId(): string {
-        if (!this._methodId) {
-            throw new MissingDataError(MissingDataErrorType.MissingPaymentMethod);
-        }
-
-        return this._methodId;
-    }
-
-    private set methodId(value: string) {
-        if (!value) {
-            throw new InvalidArgumentError();
-        }
-
-        this._methodId = value;
-    }
-
     private _createSignInButton(containerId: string): HTMLElement {
         const container = document.querySelector(`#${containerId}`);
 
@@ -97,6 +81,14 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
         container.appendChild(googlePayButton);
 
         return googlePayButton;
+    }
+
+    private _getMethodId(): string {
+        if (!this._methodId) {
+            throw new InvalidArgumentError();
+        }
+
+        return this._methodId;
     }
 
     @bind
@@ -133,7 +125,7 @@ export default class GooglePayBraintreeButtonStrategy extends CheckoutButtonStra
         return Promise.all([
             this._googlePayPaymentProcessor.updateShippingAddress(shippingAddress),
             this._store.dispatch(this._checkoutActionCreator.loadCurrentCheckout()),
-            this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this.methodId)),
+            this._store.dispatch(this._paymentMethodActionCreator.loadPaymentMethod(this._getMethodId())),
         ]).then(() => this._onPaymentSelectComplete());
     }
 


### PR DESCRIPTION
## What?
We are removing the getter and setter for `methodId`.

## Why?
Firstly, we actually don't allow computed properties in this project. get/set are forbidden because it is very easy to put logic in there that's computationally expensive or induces side effects.

Secondly, all private properties and methods need to be prefixed with _. This is because, although we're using TypeScript, the source ultimately gets compiled into JS and consumed by JS clients. So we need a way to indicate to the consumers that these properties and methods are not supposed to be used.

## Testing / Proof
![image](https://user-images.githubusercontent.com/1013633/47389086-71c84e00-d6d9-11e8-920e-351041ffb753.png)


@vmparra 